### PR TITLE
Change brew installation from deprecated curl to bash

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -58,7 +58,33 @@ echo_title "END INSTALLING ZSH"
 
 ## BREW
 echo_title "BEGIN INSTALLING BREW"
-which -s brew || /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+which -s brew
+IS_BREW_INSTALLED="$?"
+if [[ "${IS_BREW_INSTALLED}" -ne 0 ]]
+  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+  UNAME_MACHINE="$(/usr/bin/uname -m)"
+  if [[ "${UNAME_MACHINE}" == "arm64" ]] then
+    HOMEBREW_PREFIX="/opt/homebrew"
+    case "${SHELL}" in
+    */bash*)
+      if [[ -r "${HOME}/.bash_profile" ]]
+      then
+        shell_profile="${HOME}/.bash_profile"
+      else
+        shell_profile="${HOME}/.profile"
+      fi
+      ;;
+    */zsh*)
+      shell_profile="${HOME}/.zprofile"
+      ;;
+    *)
+      shell_profile="${HOME}/.profile"
+      ;;
+    esac
+    echo 'eval "\$(${HOMEBREW_PREFIX}/bin/brew shellenv)"' >> ${shell_profile}
+    eval "\$(${HOMEBREW_PREFIX}/bin/brew shellenv)"
+  fi
 brew update
 echo_title "END INSTALLING BREW"
 

--- a/install.sh
+++ b/install.sh
@@ -60,7 +60,7 @@ echo_title "END INSTALLING ZSH"
 echo_title "BEGIN INSTALLING BREW"
 which -s brew
 IS_BREW_INSTALLED="$?"
-if [[ "${IS_BREW_INSTALLED}" -ne 0 ]]
+if [[ "${IS_BREW_INSTALLED}" -ne 0 ]] then
   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
   UNAME_MACHINE="$(/usr/bin/uname -m)"
@@ -85,6 +85,7 @@ if [[ "${IS_BREW_INSTALLED}" -ne 0 ]]
     echo 'eval "\$(${HOMEBREW_PREFIX}/bin/brew shellenv)"' >> ${shell_profile}
     eval "\$(${HOMEBREW_PREFIX}/bin/brew shellenv)"
   fi
+fi
 brew update
 echo_title "END INSTALLING BREW"
 


### PR DESCRIPTION
The Ruby Homebrew installer is deprecated.
The new installation command is 
```/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"```

The homebrew installation path is not the same for x86_64 and arm64 processor architecture. Based on https://github.com/Homebrew/install/blob/e8114640740938c20cc41ffdbf07816b428afc49/install.sh#L114 and https://github.com/Homebrew/install/blob/e8114640740938c20cc41ffdbf07816b428afc49/install.sh#L979-L1000 I made the install.sh script working for both architecture.